### PR TITLE
My Like & Collections Features Add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Thumbs.db
 
 # IDE project files
 .idea
+.vscode/*

--- a/Settings.py
+++ b/Settings.py
@@ -18,6 +18,7 @@ class Settings:
 
     # Text shown in Cura's extension menu.
     MENU_TEXT = "Browse Thingiverse"
+    SETTINGS_MENU_TEXT = "Configure Settings"
     
     # Thingiverse API options
     THINGIVERSE_API_TOKEN = "d1057e7ec3da66ac1b81f8632606ca0a"

--- a/Settings.py
+++ b/Settings.py
@@ -19,6 +19,10 @@ class Settings:
     # Text shown in Cura's extension menu.
     MENU_TEXT = "Browse Thingiverse"
     SETTINGS_MENU_TEXT = "Configure Settings"
+
+    # Preference Keys
+    PREFERENCE_BASE = "ThingiBrowser"
+    PREFERENCE_USER_NAME = "user_name"
     
     # Thingiverse API options
     THINGIVERSE_API_TOKEN = "d1057e7ec3da66ac1b81f8632606ca0a"

--- a/thingiverse/ThingiverseExtension.py
+++ b/thingiverse/ThingiverseExtension.py
@@ -23,7 +23,7 @@ class ThingiverseExtension(Extension):
         super().__init__()
         
         # The API client that we do all calls to Thingiverse with.
-        self._service = ThingiverseService()  # type: ThingiverseService
+        self._service = ThingiverseService(None, self)  # type: ThingiverseService
         
         # The API client that will talk to Google Analytics.
         self._analytics = Analytics()  # type: Analytics
@@ -32,11 +32,10 @@ class ThingiverseExtension(Extension):
         self._main_dialog = None
         self._settings_dialog = None
                
-        CuraApplication.getInstance().getPreferences().addPreference("ThingiBrowser/user_name", False)
+        CuraApplication.getInstance().getPreferences().addPreference("ThingiBrowser/user_name", None)
 
         # Configure the 'extension' menu.
         self.setMenuName(Settings.DISPLAY_NAME)
-        self.addMenuItem(Settings.SETTINGS_MENU_TEXT, self._showSettingsWindow)
         self.addMenuItem(Settings.MENU_TEXT, self._showMainWindow)
 
     def _showMainWindow(self) -> None:
@@ -49,7 +48,7 @@ class ThingiverseExtension(Extension):
         self._service.updateSupportedFileTypes()
         self._service.search("ultimaker")
 
-    def _showSettingsWindow(self) -> None:
+    def showSettingsWindow(self) -> None:
         """
         Show the settings popup window.
         """

--- a/thingiverse/ThingiverseExtension.py
+++ b/thingiverse/ThingiverseExtension.py
@@ -23,7 +23,7 @@ class ThingiverseExtension(Extension):
         super().__init__()
         
         # The API client that we do all calls to Thingiverse with.
-        self._service = ThingiverseService(None, self)  # type: ThingiverseService
+        self._service = ThingiverseService(self)  # type: ThingiverseService
         
         # The API client that will talk to Google Analytics.
         self._analytics = Analytics()  # type: Analytics
@@ -32,8 +32,6 @@ class ThingiverseExtension(Extension):
         self._main_dialog = None
         self._settings_dialog = None
                
-        CuraApplication.getInstance().getPreferences().addPreference("ThingiBrowser/user_name", None)
-
         # Configure the 'extension' menu.
         self.setMenuName(Settings.DISPLAY_NAME)
         self.addMenuItem(Settings.MENU_TEXT, self._showMainWindow)

--- a/thingiverse/ThingiverseExtension.py
+++ b/thingiverse/ThingiverseExtension.py
@@ -30,9 +30,13 @@ class ThingiverseExtension(Extension):
         
         # The UI objects.
         self._main_dialog = None
-        
+        self._settings_dialog = None
+               
+        CuraApplication.getInstance().getPreferences().addPreference("ThingiBrowser/user_name", False)
+
         # Configure the 'extension' menu.
         self.setMenuName(Settings.DISPLAY_NAME)
+        self.addMenuItem(Settings.SETTINGS_MENU_TEXT, self._showSettingsWindow)
         self.addMenuItem(Settings.MENU_TEXT, self._showMainWindow)
 
     def _showMainWindow(self) -> None:
@@ -44,6 +48,14 @@ class ThingiverseExtension(Extension):
         self._main_dialog.show()
         self._service.updateSupportedFileTypes()
         self._service.search("ultimaker")
+
+    def _showSettingsWindow(self) -> None:
+        """
+        Show the settings popup window.
+        """
+        if not self._settings_dialog:
+            self._settings_dialog = self._createDialog("ThingiSettings.qml")
+        self._settings_dialog.show()
 
     def _createDialog(self, qml_file_path: str) -> Optional[QObject]:
         """

--- a/thingiverse/ThingiverseService.py
+++ b/thingiverse/ThingiverseService.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import QMessageBox
 
 from cura.CuraApplication import CuraApplication
 from .ThingiverseApiClient import ThingiverseApiClient, JSONObject
+from ..Settings import Settings
 
 class ThingiverseService(QObject):
     """
@@ -19,12 +20,12 @@ class ThingiverseService(QObject):
     thingsChanged = pyqtSignal()
 
     # Signal triggered when the from collection state changed.
-    fromCollectionChanged = pyqtSignal()
+    isFromCollectionChanged = pyqtSignal()
 
     # Signal triggered when user name changed.
     userNameChanged = pyqtSignal()
 
-    # Signal triggered whne the querying state changed.
+    # Signal triggered when the querying state changed.
     queryingStateChanged = pyqtSignal()
 
     # Signal triggered when the active thing changed.
@@ -36,16 +37,16 @@ class ThingiverseService(QObject):
     # Signal triggered when a file has started or stopped downloading.
     downloadingStateChanged = pyqtSignal()
 
-    def __init__(self, parent=None, extension=None):
+    def __init__(self, extension: "ThingiverseExtension", parent=None):
         super().__init__(parent)
 
-        self._extension = extension
+        self._extension = extension # type: ThingiverseExtension
 
         # Hold the things found in query results.
         self._things = []  # type: List[JSONObject]
         self._query = ""  # type: str
         self._query_page = 1  # type: int
-        self._from_collection = False # type: bool
+        self._is_from_collection = False # type: bool
 
         # Hold the thing and thing files that we currently see the details of.
         self._thing_details = None  # type: Optional[JSONObject]
@@ -55,11 +56,21 @@ class ThingiverseService(QObject):
         # The API client that we do all calls to Thingiverse with.
         self._api_client = ThingiverseApiClient()  # type: ThingiverseApiClient
 
-        self._user_name = CuraApplication.getInstance().getPreferences().getValue('ThingiBrowser/user_name')
-        CuraApplication.getInstance().getPreferences().preferenceChanged.connect(self._onPreferencesChanged)
+        preferences = CuraApplication.getInstance().getPreferences()
+        user_name_pref = self._formatPreferenceSetting(Settings.PREFERENCE_USER_NAME)
+        preferences.addPreference(user_name_pref, None)
+        self._user_name = preferences.getValue(user_name_pref)
+        preferences.preferenceChanged.connect(self._onPreferencesChanged)
 
         # List of supported file types.
         self._supported_file_types = []  # type: List[str]
+
+    def _formatPreferenceSetting(self, name: str) -> str:
+        """
+        Format a preference key for plugin namespace.
+        :param name: Preference key
+        """
+        return "{}/{}".format(Settings.PREFERENCE_BASE, name)
 
     def updateSupportedFileTypes(self) -> None:
         """
@@ -70,9 +81,10 @@ class ThingiverseService(QObject):
 
     def _onPreferencesChanged(self, name: str) -> None:
         """
-        On Prefrences Changed Listener
+        On Prefrences Changed Listener.
+        :param name: Name of ThingiBrowser preference
         """
-        if name != "ThingiBrowser/user_name":
+        if name != self._formatPreferenceSetting(Settings.PREFERENCE_USER_NAME):
             return
         self._user_name = CuraApplication.getInstance().getPreferences().getValue(name)
         self.userNameChanged.emit()
@@ -80,37 +92,34 @@ class ThingiverseService(QObject):
     @pyqtSlot(name="openSettings")
     def openSettings(self) -> None:
         """
-        Open the settings window
+        Open the settings window.
         """
-        if self._extension is not None:
-            self._extension.showSettingsWindow()
+        if not self._extension:
+            return
+        self._extension.showSettingsWindow()
 
     @pyqtProperty(str, notify=userNameChanged)
     def userName(self) -> str:
         """
-        User name selected
+        User name selected.
         """
-        return self._user_name if self._user_name is not None else ""
+        return self._user_name or ""
 
     @pyqtSlot(str, name="getSetting")
-    def getSetting(self, name: str) -> any:
+    def getSetting(self, name: str) -> str:
         """
-        Get a setting from preferences
+        Get a setting from preferences.
         """
-        return CuraApplication.getInstance().getPreferences().getValue('ThingiBrowser/'.name)
+        return CuraApplication.getInstance().getPreferences().getValue(self._formatPreferenceSetting(name))
 
     @pyqtSlot(str, str, name="saveSetting")
     def setSetting(self, name: str, value: str) -> None:
         """
-        Set a setting in preferences
+        Set a setting in preferences.
         """
-        CuraApplication.getInstance().getPreferences().setValue('ThingiBrowser/'+name, value)
-        if name == "user_name":
-            if value == "":
-                CuraApplication.getInstance().getPreferences().resetPreference('ThingiBrowser/'+name)
-            else:
-                self._user_name = value
-            self.userNameChanged.emit()
+        pref_name = self._formatPreferenceSetting(name)
+        CuraApplication.getInstance().getPreferences().setValue(pref_name, value)
+        self.userNameChanged.emit()
 
     @pyqtProperty("QVariantList", notify=thingsChanged)
     def things(self) -> List[Dict[str, any]]:
@@ -120,12 +129,12 @@ class ThingiverseService(QObject):
         """
         return [thing.__dict__ for thing in self._things]
 
-    @pyqtProperty(bool, notify=fromCollectionChanged)
-    def fromCollection(self) -> bool:
+    @pyqtProperty(bool, notify=isFromCollectionChanged)
+    def isFromCollection(self) -> bool:
         """
         Was the last click from a collection list?
         """
-        return self._from_collection
+        return self._is_from_collection
 
     @pyqtProperty(bool, notify=queryingStateChanged)
     def isQuerying(self) -> bool:
@@ -174,23 +183,27 @@ class ThingiverseService(QObject):
         """
         self._executeQuery("search/{}".format(search_term))
 
+    def _hasUserNameSet(self) -> None:
+        if not self._user_name:
+            self.openSettings()
+            return False
+        return True
+
     @pyqtSlot(name="getLiked")
     def getLiked(self) -> None:
         """
-        Get the current user's liked things
+        Get the current user's liked things.
         """
-        if self._user_name is None:
-            self.openSettings()
+        if not self._hasUserNameSet():
             return
         self._executeQuery("users/{}/likes".format(self._user_name))
 
     @pyqtSlot(name="getCollections")
     def getCollections(self) -> None:
         """
-        Get the current user's collections
+        Get the current user's collections.
         """
-        if self._user_name is None:
-            self.openSettings()
+        if not self._hasUserNameSet():
             return
         self._executeQuery("users/{}/collections".format(self._user_name))
 
@@ -233,7 +246,7 @@ class ThingiverseService(QObject):
         Get and show the details of a single collection.
         :param coll_id: The ID of the colleciton.
         """
-        self._executeQuery("/collections/{}/things".format(coll_id), from_collection=True)
+        self._executeQuery("/collections/{}/things".format(coll_id), is_from_collection=True)
 
     @pyqtSlot(int, name="showThingDetails")
     def showThingDetails(self, thing_id: int) -> None:
@@ -264,18 +277,19 @@ class ThingiverseService(QObject):
         self.downloadingStateChanged.emit()
         self._api_client.downloadThingFile(file_id, lambda data: self._onDownloadFinished(data, file_name))
 
-    def _executeQuery(self, new_query: Optional[str] = None, from_collection: Optional[bool] = False) -> None:
+    def _executeQuery(self, new_query: Optional[str] = None, is_from_collection: Optional[bool] = False) -> None:
         """
         Internal function to query the API for things.
         :param new_query: Perform a new query instead of adding a new page to the existing one.
+        :param is_from_collection: Specifies whether the resulting Things are part of a collection or not
         """
         if new_query:
             self._query = new_query
             self._clearSearchResults()
             self._query_page = 1
-        if self._from_collection != from_collection:
-            self._from_collection = from_collection
-            self.fromCollectionChanged.emit()
+        if self._is_from_collection != is_from_collection:
+            self._is_from_collection = is_from_collection
+            self.isFromCollectionChanged.emit()
         self._is_querying = True
         self.queryingStateChanged.emit()
         self._api_client.get(self._query, page=self._query_page, on_finished=self._onQueryFinished,

--- a/thingiverse/ThingiverseService.py
+++ b/thingiverse/ThingiverseService.py
@@ -44,6 +44,9 @@ class ThingiverseService(QObject):
         # The API client that we do all calls to Thingiverse with.
         self._api_client = ThingiverseApiClient()  # type: ThingiverseApiClient
 
+        self._user_name = CuraApplication.getInstance().getPreferences().getValue('ThingiBrowser/user_name')
+        CuraApplication.getInstance().getPreferences().preferenceChanged.connect(self._onPreferencesChanged)
+
         # List of supported file types.
         self._supported_file_types = []  # type: List[str]
 
@@ -53,6 +56,14 @@ class ThingiverseService(QObject):
         """
         supported_file_types = CuraApplication.getInstance().getMeshFileHandler().getSupportedFileTypesRead()
         self._supported_file_types = list(supported_file_types.keys())
+
+    def _onPreferencesChanged(self, name: str) -> None:
+        """
+        On Prefrences Changed Listener
+        """
+        if name != "ThingiBrowser/user_name":
+            return
+        self._user_name = CuraApplication.getInstance().getPreferences().getValue(name)
 
     @pyqtProperty("QVariantList", notify=thingsChanged)
     def things(self) -> List[Dict[str, any]]:
@@ -101,6 +112,13 @@ class ThingiverseService(QObject):
         :param search_term: What to search for.
         """
         self._executeQuery("search/{}".format(search_term))
+
+    @pyqtSlot(name="getLiked")
+    def getLiked(self) -> None:
+        """
+        Get the current user's liked things
+        """
+        self._executeQuery("users/{}/likes".format(self._user_name))
 
     @pyqtSlot(name="getPopular")
     def getPopular(self) -> None:

--- a/views/ConfigButton.qml
+++ b/views/ConfigButton.qml
@@ -1,0 +1,61 @@
+import QtQuick 2.2
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import UM 1.1 as UM
+import Cura 1.0 as Cura
+import QtGraphicalEffects 1.0 // For the dropshadow
+
+Button
+{
+    id: configButton
+    height: parent.height
+    width: parent.height // make it square
+
+    property color backgroundColor: UM.Theme.getColor("action_button")
+    property color hoverColor: UM.Theme.getColor("toolbar_button_hover")
+    onClicked: {
+        ThingiService.openSettings()
+    }
+    hoverEnabled: true
+
+    contentItem: Item
+    {
+        anchors.fill: parent
+        UM.RecolorImage
+        {
+            id: buttonIcon
+            anchors.centerIn: parent
+            source: UM.Theme.getIcon("settings")
+            width: UM.Theme.getSize("button_icon").width - UM.Theme.getSize("default_margin").width
+            height: UM.Theme.getSize("button_icon").height - UM.Theme.getSize("default_margin").height
+            color: UM.Theme.getColor("icon")
+
+            sourceSize.height: height
+        }
+    }
+
+    background: Rectangle
+    {
+        id: configBackground
+        height: UM.Theme.getSize("toolbox_header").height
+        width: UM.Theme.getSize("toolbox_header").height
+
+        radius: UM.Theme.getSize("default_radius").width
+        border.color: UM.Theme.getColor("lining")
+        color: configButton.hovered ? hoverColor : backgroundColor
+    }
+
+    DropShadow
+    {
+        id: shadow
+        // Don't blur the shadow
+        radius: 0
+        anchors.fill: configBackground
+        source: configBackground
+        verticalOffset: 2
+        visible: true
+        color: UM.Theme.getColor("action_button_shadow")
+        // Should always be drawn behind the background.
+        z: configBackground.z - 1
+    }
+}

--- a/views/ThingSearchPage.qml
+++ b/views/ThingSearchPage.qml
@@ -27,7 +27,7 @@ ColumnLayout
         visible: ThingiService.isFromCollection === true && ThingiService.isQuerying === false
         Layout.leftMargin: 20
         Layout.topMargin: 10
-        Layout.bottomMargin: 20
+        Layout.bottomMargin: 10
     }
 
     ThingsList

--- a/views/ThingSearchPage.qml
+++ b/views/ThingSearchPage.qml
@@ -18,6 +18,17 @@ ColumnLayout
         Layout.topMargin: (parent.height / 2) - (height / 2)
     }
 
+    Cura.SecondaryButton
+    {
+        text: "Back to collections"
+        onClicked: {
+            ThingiService.getCollections();
+        }
+        visible: ThingiService.fromCollection === true && ThingiService.isQuerying === false
+        Layout.leftMargin: 20
+        Layout.bottomMargin: 20
+    }
+
     ThingsList
     {
         id: thingsList

--- a/views/ThingSearchPage.qml
+++ b/views/ThingSearchPage.qml
@@ -24,8 +24,9 @@ ColumnLayout
         onClicked: {
             ThingiService.getCollections();
         }
-        visible: ThingiService.fromCollection === true && ThingiService.isQuerying === false
+        visible: ThingiService.isFromCollection === true && ThingiService.isQuerying === false
         Layout.leftMargin: 20
+        Layout.topMargin: 10
         Layout.bottomMargin: 20
     }
 

--- a/views/ThingiHeader.qml
+++ b/views/ThingiHeader.qml
@@ -73,6 +73,15 @@ Rectangle
 
         Cura.SecondaryButton
         {
+            text: "My Likes"
+            onClicked: {
+                ThingiService.getLiked()
+            }
+            Layout.alignment: Qt.AlignCenter
+        }
+
+        Cura.SecondaryButton
+        {
             text: "Popular"
             onClicked: {
                 ThingiService.getPopular()

--- a/views/ThingiHeader.qml
+++ b/views/ThingiHeader.qml
@@ -82,6 +82,15 @@ Rectangle
 
         Cura.SecondaryButton
         {
+            text: "My Collections"
+            onClicked: {
+                ThingiService.getCollections()
+            }
+            Layout.alignment: Qt.AlignCenter
+        }
+
+        Cura.SecondaryButton
+        {
             text: "Popular"
             onClicked: {
                 ThingiService.getPopular()

--- a/views/ThingiHeader.qml
+++ b/views/ThingiHeader.qml
@@ -15,109 +15,152 @@ Rectangle
 
     width: parent.width
     Layout.fillWidth: true
-    height: UM.Theme.getSize("toolbox_header").height
+    height: UM.Theme.getSize("toolbox_header").height * 2
     color: "#f5f5f5"
 
-    RowLayout
+    GridLayout
     {
-        height: parent.height
-        width: parent.width
+        columns: 2
+        Layout.minimumWidth: parent.width
+        Layout.fillWidth: true
+        anchors.margins: 20
+        anchors.fill: parent
 
-        Image
+        RowLayout
         {
-            sourceSize.width: 100
-            source: "thingiverse-logo-2015.png"
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
+            id: topLeftCell
+            width: parent.width * 2/3
 
-            // make the header image clickable
-            MouseArea
+            Image
             {
-            	anchors.fill: parent
-				onClicked: {
-					ThingiService.search("ultimaker")
-            		Analytics.trackEvent("header_image", "clicked")
-				}
-				hoverEnabled: true
-				cursorShape: Qt.PointingHandCursor
-			}
-        }
+                sourceSize.width: 100
+                source: "thingiverse-logo-2015.png"
+                Layout.rightMargin: 20
 
-        TextField
-        {
-            id: thingSearchField
-            placeholderText: "Search for things..."
-            Layout.alignment: Qt.AlignCenter
-            Layout.preferredWidth: parent.width / 4
-            onAccepted: {
-                ThingiService.search(thingSearchField.text)
-                Analytics.trackEvent("search_field", "enter_pressed")
+                // make the header image clickable
+                MouseArea
+                {
+                    anchors.fill: parent
+                    onClicked: {
+                        ThingiService.search("ultimaker")
+                        Analytics.trackEvent("header_image", "clicked")
+                    }
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                }
             }
-            selectByMouse: true
-        }
 
-        Cura.PrimaryButton
-        {
-            text: "Search"
-            onClicked: {
-                ThingiService.search(thingSearchField.text)
-                Analytics.trackEvent("search_field", "button_clicked")
+            TextField
+            {
+                id: thingSearchField
+                placeholderText: "Search for things..."
+                Layout.alignment: Qt.AlignCenter
+                Layout.fillWidth: true
+                onAccepted: {
+                    ThingiService.search(thingSearchField.text)
+                    Analytics.trackEvent("search_field", "enter_pressed")
+                }
+                selectByMouse: true
             }
-            Layout.alignment: Qt.AlignCenter
-        }
 
-        Item
-        {
-            Layout.fillWidth: true // create some space between the search section and the other buttons
-        }
-
-        Cura.SecondaryButton
-        {
-            text: "My Likes"
-            onClicked: {
-                ThingiService.getLiked()
+            Cura.PrimaryButton
+            {
+                text: "Search"
+                onClicked: {
+                    ThingiService.search(thingSearchField.text)
+                    Analytics.trackEvent("search_field", "button_clicked")
+                }
+                Layout.alignment: Qt.AlignCenter
             }
-            Layout.alignment: Qt.AlignCenter
         }
 
-        Cura.SecondaryButton
+        RowLayout
         {
-            text: "My Collections"
-            onClicked: {
-                ThingiService.getCollections()
+            id: topRightCell
+
+            Item
+            {
+                Layout.fillWidth: true
             }
-            Layout.alignment: Qt.AlignCenter
+
+            Cura.SecondaryButton
+            {
+                text: "My Likes"
+                onClicked: {
+                    ThingiService.getLiked()
+                }
+                Layout.alignment: Qt.AlignCenter
+            }
+
+            Cura.SecondaryButton
+            {
+                text: "My Collections"
+                onClicked: {
+                    ThingiService.getCollections()
+                }
+                Layout.alignment: Qt.AlignCenter
+            }
+
+            Cura.SecondaryButton
+            {
+                iconSource: UM.Theme.getIcon("settings")
+                Layout.minimumHeight: parent.height
+                onClicked: {
+                    ThingiService.openSettings()
+                }
+                Layout.alignment: Qt.AlignCenter
+            }
+            
         }
 
-        Cura.SecondaryButton
+        RowLayout
         {
-            text: "Popular"
-            onClicked: {
-                ThingiService.getPopular()
-                Analytics.trackEvent("get_popular", "button_clicked")
+            id: bottomLeftCell
+
+            Item
+            {
+                Layout.fillWidth: true
             }
-            Layout.alignment: Qt.AlignCenter
         }
 
-        Cura.SecondaryButton
+        RowLayout
         {
-            text: "Featured"
-            onClicked: {
-                ThingiService.getFeatured()
-                Analytics.trackEvent("get_featured", "button_clicked")
-            }
-            Layout.alignment: Qt.AlignCenter
-        }
+            id: bottomRightCell
 
-        Cura.SecondaryButton
-        {
-            text: "Newest"
-            onClicked: {
-                ThingiService.getNewest()
-                Analytics.trackEvent("get_newest", "button_clicked")
+            Item 
+            {
+                Layout.fillWidth: true
             }
-            Layout.alignment: Qt.AlignCenter
-            Layout.rightMargin: 20 // we need some padding from the right edge of the window
+
+            Cura.SecondaryButton
+            {
+                text: "Popular"
+                onClicked: {
+                    ThingiService.getPopular()
+                    Analytics.trackEvent("get_popular", "button_clicked")
+                }
+                Layout.alignment: Qt.AlignCenter
+            }
+
+            Cura.SecondaryButton
+            {
+                text: "Featured"
+                onClicked: {
+                    ThingiService.getFeatured()
+                    Analytics.trackEvent("get_featured", "button_clicked")
+                }
+                Layout.alignment: Qt.AlignCenter
+            }
+
+            Cura.SecondaryButton
+            {
+                text: "Newest"
+                onClicked: {
+                    ThingiService.getNewest()
+                    Analytics.trackEvent("get_newest", "button_clicked")
+                }
+                Layout.alignment: Qt.AlignCenter
+            }
         }
     }
 }

--- a/views/ThingiHeader.qml
+++ b/views/ThingiHeader.qml
@@ -2,165 +2,39 @@
 // Thingiverse plugin is released under the terms of the LGPLv3 or higher.
 import QtQuick 2.2
 import QtQuick.Controls 2.0
-import QtQuick.Dialogs 1.1
 import QtQuick.Layouts 1.3
-import QtQuick.Window 2.2
 import UM 1.1 as UM
 import Cura 1.0 as Cura
+import QtGraphicalEffects 1.0 // For the dropshadow
 
 // the main window header
-Rectangle
+Item
 {
     id: header
-
     width: parent.width
-    Layout.fillWidth: true
-    height: UM.Theme.getSize("toolbox_header").height * 2
-    color: "#f5f5f5"
+    height: UM.Theme.getSize("toolbox_header").height
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.margins: 20
+    Layout.bottomMargin: 20
 
-    GridLayout
+    ThingiSearchbar
     {
-        columns: 2
-        Layout.minimumWidth: parent.width
-        Layout.fillWidth: true
-        anchors.margins: 20
-        anchors.fill: parent
+        id: searchbar
+        height: parent.height
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: configButton.left
+        anchors.rightMargin: 10
+    }
 
-        RowLayout
-        {
-            id: topLeftCell
-            width: parent.width * 2/3
-
-            Image
-            {
-                sourceSize.width: 100
-                source: "thingiverse-logo-2015.png"
-                Layout.rightMargin: 20
-
-                // make the header image clickable
-                MouseArea
-                {
-                    anchors.fill: parent
-                    onClicked: {
-                        ThingiService.search("ultimaker")
-                        Analytics.trackEvent("header_image", "clicked")
-                    }
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                }
-            }
-
-            TextField
-            {
-                id: thingSearchField
-                placeholderText: "Search for things..."
-                Layout.alignment: Qt.AlignCenter
-                Layout.fillWidth: true
-                onAccepted: {
-                    ThingiService.search(thingSearchField.text)
-                    Analytics.trackEvent("search_field", "enter_pressed")
-                }
-                selectByMouse: true
-            }
-
-            Cura.PrimaryButton
-            {
-                text: "Search"
-                onClicked: {
-                    ThingiService.search(thingSearchField.text)
-                    Analytics.trackEvent("search_field", "button_clicked")
-                }
-                Layout.alignment: Qt.AlignCenter
-            }
-        }
-
-        RowLayout
-        {
-            id: topRightCell
-
-            Item
-            {
-                Layout.fillWidth: true
-            }
-
-            Cura.SecondaryButton
-            {
-                text: "My Likes"
-                onClicked: {
-                    ThingiService.getLiked()
-                }
-                Layout.alignment: Qt.AlignCenter
-            }
-
-            Cura.SecondaryButton
-            {
-                text: "My Collections"
-                onClicked: {
-                    ThingiService.getCollections()
-                }
-                Layout.alignment: Qt.AlignCenter
-            }
-
-            Cura.SecondaryButton
-            {
-                iconSource: UM.Theme.getIcon("settings")
-                Layout.minimumHeight: parent.height
-                onClicked: {
-                    ThingiService.openSettings()
-                }
-                Layout.alignment: Qt.AlignCenter
-            }
-            
-        }
-
-        RowLayout
-        {
-            id: bottomLeftCell
-
-            Item
-            {
-                Layout.fillWidth: true
-            }
-        }
-
-        RowLayout
-        {
-            id: bottomRightCell
-
-            Item 
-            {
-                Layout.fillWidth: true
-            }
-
-            Cura.SecondaryButton
-            {
-                text: "Popular"
-                onClicked: {
-                    ThingiService.getPopular()
-                    Analytics.trackEvent("get_popular", "button_clicked")
-                }
-                Layout.alignment: Qt.AlignCenter
-            }
-
-            Cura.SecondaryButton
-            {
-                text: "Featured"
-                onClicked: {
-                    ThingiService.getFeatured()
-                    Analytics.trackEvent("get_featured", "button_clicked")
-                }
-                Layout.alignment: Qt.AlignCenter
-            }
-
-            Cura.SecondaryButton
-            {
-                text: "Newest"
-                onClicked: {
-                    ThingiService.getNewest()
-                    Analytics.trackEvent("get_newest", "button_clicked")
-                }
-                Layout.alignment: Qt.AlignCenter
-            }
-        }
+    ConfigButton
+    {
+        id: configButton
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
     }
 }

--- a/views/ThingiSearchbar.qml
+++ b/views/ThingiSearchbar.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import UM 1.1 as UM
+import Cura 1.0 as Cura
+import QtGraphicalEffects 1.0 // For the dropshadow
+
+Item {
+    id: searchbar
+
+    RowLayout
+    {
+        height: parent.height
+        width: parent.width
+        spacing: 0
+
+        Image
+        {
+            sourceSize.width: 100
+            source: "thingiverse-logo-2015.png"
+            Layout.leftMargin: UM.Theme.getSize("default_margin").width
+            Layout.rightMargin: UM.Theme.getSize("default_margin").width
+
+            // make the header image clickable
+            MouseArea
+            {
+                anchors.fill: parent
+                onClicked: {
+                    viewSelector.labelText = "Custom Search"
+                    ThingiService.search("ultimaker")
+                    Analytics.trackEvent("header_image", "clicked")
+                }
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+            }
+        }
+
+        TextField
+        {
+            id: thingSearchField
+            placeholderText: "Search for things..."
+            Layout.alignment: Qt.AlignCenter
+            Layout.fillWidth: true
+            Layout.rightMargin: UM.Theme.getSize("default_margin").width
+            onAccepted: {
+                viewSelector.labelText = "Custom Search"
+                ThingiService.search(thingSearchField.text)
+                Analytics.trackEvent("search_field", "enter_pressed")
+            }
+            selectByMouse: true
+        }
+
+        Cura.PrimaryButton
+        {
+            text: "Search"
+            onClicked: {
+                viewSelector.labelText = "Custom Search"
+                ThingiService.search(thingSearchField.text)
+                Analytics.trackEvent("search_field", "button_clicked")
+            }
+            Layout.alignment: Qt.AlignCenter
+            Layout.rightMargin: UM.Theme.getSize("default_margin").width
+        }
+
+        // Separator line
+        Rectangle
+        {
+            id: separatorLine
+            height: parent.height
+            width: UM.Theme.getSize("default_lining").width
+            color: UM.Theme.getColor("lining")
+        }
+
+        ViewSelector
+        {
+            id: viewSelector
+            headerRadius: 5
+            headerCornerSide: 4
+            enableHeaderShadow: false
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.margins: searchbarBackground.border.width
+            Layout.margins: searchbarBackground.border.width
+        }
+    }
+
+    Rectangle
+    {
+        id: searchbarBackground
+        height: parent.height
+        width: parent.width
+        color: UM.Theme.getColor("main_background")
+        border.color: UM.Theme.getColor("lining")
+        radius: UM.Theme.getSize("default_radius").width
+        z: parent.z - 1
+    }
+
+    DropShadow
+    {
+        id: searchbarShadow
+        // Don't blur the shadow
+        radius: 0
+        anchors.fill: searchbarBackground
+        source: searchbarBackground
+        verticalOffset: 2
+        visible: true
+        color: UM.Theme.getColor("action_button_shadow")
+        // Should always be drawn behind the background.
+        z: searchbarBackground.z - 1
+    }
+}

--- a/views/ThingiSettings.qml
+++ b/views/ThingiSettings.qml
@@ -1,0 +1,81 @@
+// Copyright (c) 2018 Chris ter Beke.
+// Thingiverse plugin is released under the terms of the LGPLv3 or higher.
+import QtQuick 2.2
+import QtQuick.Controls 2.0
+import QtQuick.Dialogs 1.1
+import QtQuick.Layouts 1.3
+import QtQuick.Window 2.2
+import UM 1.1 as UM
+import Cura 1.0 as Cura
+
+// the popup window
+Window
+{
+    id: thingisettings
+
+    // window configuration
+    color: UM.Theme.getColor("main_background")
+    minimumWidth: Math.round(UM.Theme.getSize("modal_window_minimum").width)
+    minimumHeight: Math.round(UM.Theme.getSize("modal_window_minimum").height)
+    width: minimumWidth
+    height: minimumHeight
+
+    title: "Thingiverse Settings"
+
+    // area to provide un-focus option for search field
+    MouseArea
+    {
+        anchors.fill: parent
+        focus: true
+        onClicked: {
+            focus = true
+        }
+    }
+
+    ColumnLayout
+    {
+        width: parent.width
+
+        RowLayout
+        {
+            Layout.topMargin: 20
+            Layout.leftMargin: 20
+            Layout.rightMargin: 20
+
+            Label
+            {
+                id: lblThingiUserField
+                text: "Account Name"
+                Layout.alignment: Qt.AlignLeft
+                font: UM.Theme.getFont("large")
+                color: UM.Theme.getColor("text")
+                renderType: Text.NativeRendering
+                Layout.rightMargin: 10
+            }
+
+            TextField
+            {
+                id: thingiUserField
+                placeholderText: "Your Account Name..."
+                text: UM.Preferences.getValue("ThingiBrowser/user_name")
+                Layout.alignment: Qt.AlignLeft
+                Layout.fillWidth: true
+                onAccepted: {
+                    UM.Preferences.saveValue("ThingiBrowser/user_name", thingiUserField.text)
+                }
+                selectByMouse: true
+            }
+        }
+
+        Cura.PrimaryButton
+        {
+            text: "Save"
+            onClicked: {
+                UM.Preferences.saveValue("ThingiBrowser/user_name", thingiUserField.text)
+                thingisettings.close()
+            }
+            Layout.rightMargin: 20
+            Layout.alignment: Qt.AlignRight
+        }
+    }
+}

--- a/views/ThingiSettings.qml
+++ b/views/ThingiSettings.qml
@@ -34,19 +34,21 @@ Window
 
     ColumnLayout
     {
-        width: parent.width
+        anchors.fill: parent
+        anchors.margins: 20
 
-        RowLayout
+        GridLayout
         {
-            Layout.topMargin: 20
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
+            columns: 2
+            Layout.minimumWidth: parent.width
+            Layout.minimumHeight: parent.height - UM.Theme.getSize("toolbox_header").height
+            Layout.fillHeight: true
 
             Label
             {
                 id: lblThingiUserField
                 text: "Account Name"
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight | Qt.AlignTop
                 font: UM.Theme.getFont("large")
                 color: UM.Theme.getColor("text")
                 renderType: Text.NativeRendering
@@ -57,25 +59,34 @@ Window
             {
                 id: thingiUserField
                 placeholderText: "Your Account Name..."
-                text: UM.Preferences.getValue("ThingiBrowser/user_name")
-                Layout.alignment: Qt.AlignLeft
+                text: ThingiService.userName
+                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                 Layout.fillWidth: true
                 onAccepted: {
-                    UM.Preferences.saveValue("ThingiBrowser/user_name", thingiUserField.text)
+                    ThingiService.saveSetting("user_name", thingiUserField.text)
+                    thingisettings.close()
                 }
                 selectByMouse: true
             }
         }
 
-        Cura.PrimaryButton
+        RowLayout
         {
-            text: "Save"
-            onClicked: {
-                UM.Preferences.saveValue("ThingiBrowser/user_name", thingiUserField.text)
-                thingisettings.close()
+            Item
+            {
+                Layout.fillWidth: true
             }
-            Layout.rightMargin: 20
-            Layout.alignment: Qt.AlignRight
+
+            Cura.PrimaryButton
+            {
+                id: btnSave
+                text: "Save"
+                onClicked: {
+                    ThingiService.saveSetting("user_name", thingiUserField.text)
+                    thingisettings.close()
+                }
+                Layout.alignment: Qt.AlignRight
+            }
         }
     }
 }

--- a/views/ThingiSettings.qml
+++ b/views/ThingiSettings.qml
@@ -14,7 +14,7 @@ Window
     id: thingisettings
 
     // window configuration
-    color: UM.Theme.getColor("main_background")
+    color: UM.Theme.getColor("viewport_background")
     minimumWidth: Math.round(UM.Theme.getSize("license_window_minimum").width)
     width: minimumWidth
 

--- a/views/ThingiSettings.qml
+++ b/views/ThingiSettings.qml
@@ -15,10 +15,8 @@ Window
 
     // window configuration
     color: UM.Theme.getColor("main_background")
-    minimumWidth: Math.round(UM.Theme.getSize("modal_window_minimum").width)
-    minimumHeight: Math.round(UM.Theme.getSize("modal_window_minimum").height)
+    minimumWidth: Math.round(UM.Theme.getSize("license_window_minimum").width)
     width: minimumWidth
-    height: minimumHeight
 
     title: "Thingiverse Settings"
 

--- a/views/Thingiverse.qml
+++ b/views/Thingiverse.qml
@@ -13,7 +13,7 @@ Window
     id: thingiverse
 
     // window configuration
-    color: UM.Theme.getColor("main_background")
+    color: UM.Theme.getColor("viewport_background")
     minimumWidth: Math.round(UM.Theme.getSize("modal_window_minimum").width)
     minimumHeight: Math.round(UM.Theme.getSize("modal_window_minimum").height)
     width: minimumWidth

--- a/views/ThingsListItem.qml
+++ b/views/ThingsListItem.qml
@@ -56,11 +56,11 @@ Item
         {
             text: catalog.i18nc("@button", "Details")
             onClicked: {
-                Analytics.trackEvent("more_details", "button_clicked");
-                if (thing.url.indexOf('/collections/') > 0) {
-                    ThingiService.showCollectionDetails(thing.id);
+                Analytics.trackEvent("more_details", "button_clicked")
+                if (thing.url.indexOf("/collections/") > 0) {
+                    ThingiService.showCollectionDetails(thing.id)
                 } else {
-                    ThingiService.showThingDetails(thing.id);
+                    ThingiService.showThingDetails(thing.id)
                 }
             }
             Layout.rightMargin: 20

--- a/views/ThingsListItem.qml
+++ b/views/ThingsListItem.qml
@@ -56,8 +56,12 @@ Item
         {
             text: catalog.i18nc("@button", "Details")
             onClicked: {
-                Analytics.trackEvent("more_details", "button_clicked")
-                ThingiService.showThingDetails(thing.id)
+                Analytics.trackEvent("more_details", "button_clicked");
+                if (thing.url.indexOf('/collections/') > 0) {
+                    ThingiService.showCollectionDetails(thing.id);
+                } else {
+                    ThingiService.showThingDetails(thing.id);
+                }
             }
             Layout.rightMargin: 20
         }

--- a/views/ViewButton.qml
+++ b/views/ViewButton.qml
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 Chris ter Beke.
+// Thingiverse plugin is released under the terms of the LGPLv3 or higher.
+import QtQuick 2.2
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import UM 1.1 as UM
+import Cura 1.0 as Cura
+
+Label
+{
+    id: buttonLabel
+
+    property color backgroundColor: UM.Theme.getColor("action_button")
+    property color hoverColor: UM.Theme.getColor("toolbar_button_hover")
+    signal clicked()
+    color: UM.Theme.getColor("text")
+    background: Rectangle
+    {
+        id: background
+        height: parent.height
+        width: parent.width
+        color: backgroundColor
+        radius: 0
+        anchors.fill: parent
+    }
+    font: UM.Theme.getFont("medium")
+    width: parent.width
+    Layout.fillWidth: true
+    Layout.alignment: Qt.AlignLeft | Qt.AlignCenter
+    padding: UM.Theme.getSize("default_margin").height
+
+    MouseArea
+    {
+        id: mouseArea
+        anchors.fill: parent
+        onClicked: buttonLabel.clicked()
+        onEntered: background.color = hoverColor
+        onExited: background.color = backgroundColor
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+    }
+}

--- a/views/ViewButtonSeparator.qml
+++ b/views/ViewButtonSeparator.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.2
+import QtQuick.Layouts 1.3
+import UM 1.1 as UM
+
+// Separator line
+Rectangle
+{
+    height: UM.Theme.getSize("default_lining").height
+    width: parent.width
+    Layout.fillWidth: true
+    color: UM.Theme.getColor("lining")
+}

--- a/views/ViewSelector.qml
+++ b/views/ViewSelector.qml
@@ -1,0 +1,110 @@
+import QtQuick 2.2
+import QtQuick.Controls 2.0
+import QtQuick.Dialogs 1.1
+import QtQuick.Layouts 1.3
+import QtQuick.Window 2.2
+import QtGraphicalEffects 1.0 // For the dropshadow
+import UM 1.1 as UM
+import Cura 1.0 as Cura
+
+Cura.ExpandablePopup
+{
+    id: viewSelector
+    implicitHeight: parent.height
+    implicitWidth: 200 * screenScaleFactor
+    headerPadding: 20
+    contentPadding: 0
+    headerBackgroundColor: UM.Theme.getColor("main_background")
+    headerHoverColor: UM.Theme.getColor("toolbar_button_hover")
+    contentBackgroundColor: UM.Theme.getColor("main_background")
+    contentAlignment: Cura.ExpandablePopup.ContentAlignment.AlignLeft
+
+    property string labelText: "Custom Search"
+
+    function setAndToggle(selectedName) {
+        viewSelector.toggleContent()
+        labelText = selectedName
+    }
+
+    headerItem: Label
+    {
+        id: viewSelectorLabel
+        text: viewSelector.labelText
+        color: UM.Theme.getColor("text")
+        font: UM.Theme.getFont("medium")
+        verticalAlignment: Qt.AlignVCenter
+    }
+
+    contentItem: ColumnLayout
+    {
+        id: contentContainer
+        spacing: 0
+
+        ViewButton
+        {
+            text: "My Likes"
+            backgroundColor: UM.Theme.getColor("main_background")
+            onClicked: {
+                viewSelector.setAndToggle(text)
+                ThingiService.getLiked()
+            }
+        }
+
+        ViewButtonSeparator { /* No Attributes Needed */ }
+
+        ViewButton
+        {
+            text: "My Collections"
+            backgroundColor: UM.Theme.getColor("main_background")
+            onClicked: {
+                viewSelector.setAndToggle(text)
+                ThingiService.getCollections()
+            }
+        }
+
+        ViewButtonSeparator { /* No Attributes Needed */ }
+
+        ViewButton
+        {
+            text: "Popular"
+            backgroundColor: UM.Theme.getColor("main_background")
+            onClicked: {
+                viewSelector.setAndToggle(text)
+                ThingiService.getPopular()
+                Analytics.trackEvent("get_popular", "button_clicked")
+            }
+        }
+
+        ViewButtonSeparator { /* No Attributes Needed */ }
+
+        ViewButton
+        {
+            text: "Featured"
+            backgroundColor: UM.Theme.getColor("main_background")
+            onClicked: {
+                viewSelector.setAndToggle(text)
+                ThingiService.getFeatured()
+                Analytics.trackEvent("get_featured", "button_clicked")
+            }
+        }
+
+        ViewButtonSeparator { /* No Attributes Needed */ }
+
+        ViewButton
+        {
+            text: "Newest"
+            backgroundColor: UM.Theme.getColor("main_background")
+            onClicked: {
+                viewSelector.setAndToggle(text)
+                ThingiService.getNewest()
+                Analytics.trackEvent("get_newest", "button_clicked")
+            }
+        }
+
+        ViewButtonSeparator { /* No Attributes Needed */ }
+    }
+
+    Component.onCompleted: {
+        contentContainer.width = viewSelector.width + viewSelector.anchors.margins
+    }
+}


### PR DESCRIPTION
This pull request adds features for pulling a user's "My Likes" and "My Collections". With the assumption that everyone's likes and collections are public, there is a settings page that just stores the user name of the current person with no auth needed with Thingiverse. (I may look into this in the future)

Changes:
- Header
  - Added new buttons for My Likes, My Collections, and Config
  - Doubled height to accommodate new buttons
- Config
  - Starting of a configuration window for housing any preferences/configs required by plugin

Furture Enhancements I'd like to do:
- Use the catalog for translation
- Look into authentication for getting things like unpublished things from their account
  - Might need a Client ID of some sort?

