### PR TITLE
Fix spacing in search bar row

### DIFF
--- a/views/ThingiSearchbar.qml
+++ b/views/ThingiSearchbar.qml
@@ -5,6 +5,9 @@ import UM 1.1 as UM
 
 RowLayout
 {
+    height: 40
+    spacing: 0
+
     TextField
     {
         id: thingSearchField
@@ -20,7 +23,6 @@ RowLayout
     Button
     {
         text: "Search"
-        Layout.alignment: Qt.AlignLeft
         onClicked: {
             ThingiService.search(thingSearchField.text)
             Analytics.trackEvent("search_field", "button_clicked")


### PR DESCRIPTION
The default spacing for a `RowLayout` is 5. Reduce it to 0.