### PR TITLE
Also run CI for external pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adding `pull_request` to the workflow tells GitHub to also run the workflow for external pull requests. An unfortunate side effect is that for 'internal pull requests', the workflow is running twice, but we'll take that for granted right now.