### PR TITLE
Fixing bugs and refactoring

### DIFF
--- a/ThingiBrowser/PreferencesHelper.py
+++ b/ThingiBrowser/PreferencesHelper.py
@@ -26,9 +26,11 @@ class PreferencesHelper:
         return preferences.getValue(preference_key)
 
     @classmethod
-    def getAllSettings(cls) -> List[Dict[str, Any]]:
+    def getAllSettings(cls, drivers: Dict[str, str], views: Dict[str, str]) -> List[Dict[str, Any]]:
         """
         Get all settings as key:value dict.
+        :param drivers: The available drivers.
+        :param views: The available views.
         :return: The settings dict.
         """
         return [
@@ -49,7 +51,14 @@ class PreferencesHelper:
                 "key": Settings.DEFAULT_API_CLIENT_PREFERENCES_KEY,
                 "value": cls.getSettingValue(Settings.DEFAULT_API_CLIENT_PREFERENCES_KEY),
                 "label": "Default repository service",
-                "options": Settings.DRIVERS
+                "options": drivers
+            },
+            {
+                "type": "combobox",
+                "key": Settings.DEFAULT_VIEW_PREFERENCES_KEY,
+                "value": cls.getSettingValue(Settings.DEFAULT_VIEW_PREFERENCES_KEY),
+                "label": "Default view",
+                "options": views
             }
         ]
 

--- a/ThingiBrowser/Settings.py
+++ b/ThingiBrowser/Settings.py
@@ -22,11 +22,6 @@ class Settings:
     # Generic API settings
     PER_PAGE = 20
 
-    DRIVERS = [
-        {"key": "thingiverse", "label": "Thingiverse"},
-        {"key": "myminifactory", "label": "MyMiniFactory"}
-    ]
-
     # Thingiverse API options
     THINGIVERSE_API_TOKEN = "d1057e7ec3da66ac1b81f8632606ca0a"
 
@@ -38,6 +33,7 @@ class Settings:
     THINGIVERSE_USER_NAME_PREFERENCES_KEY = "user_name"
     MYMINIFACTORY_USER_NAME_PREFERENCES_KEY = "myminifactory_user_name"
     DEFAULT_API_CLIENT_PREFERENCES_KEY = "default_api_client"
+    DEFAULT_VIEW_PREFERENCES_KEY = "default_view"
 
     # Google Analytics API options
     ANALYTICS_ID = "UA-16646729-7"

--- a/ThingiBrowser/api/AbstractApiClient.py
+++ b/ThingiBrowser/api/AbstractApiClient.py
@@ -24,15 +24,6 @@ class AbstractApiClient(ABC):
 
     @property
     @abstractmethod
-    def available_views(self) -> List[str]:
-        """
-        Get the available UI views for this provider.
-        :return: A list of views to show when this provider is active.
-        """
-        raise NotImplementedError("available_views must be implemented")
-
-    @property
-    @abstractmethod
     def user_id(self) -> str:
         """
         Get the configured user ID for this provider.

--- a/ThingiBrowser/drivers/myminifactory/MyMiniFactoryApiClient.py
+++ b/ThingiBrowser/drivers/myminifactory/MyMiniFactoryApiClient.py
@@ -20,10 +20,6 @@ class MyMiniFactoryApiClient(AbstractApiClient):
         PreferencesHelper.initSetting(Settings.MYMINIFACTORY_USER_NAME_PREFERENCES_KEY, "")
 
     @property
-    def available_views(self) -> List[str]:
-        return ["userLikes", "userCollections", "userThings", "popular", "featured", "newest"]
-
-    @property
     def user_id(self) -> str:
         return PreferencesHelper.getSettingValue(Settings.MYMINIFACTORY_USER_NAME_PREFERENCES_KEY)
 

--- a/ThingiBrowser/drivers/thingiverse/ThingiverseApiClient.py
+++ b/ThingiBrowser/drivers/thingiverse/ThingiverseApiClient.py
@@ -19,10 +19,6 @@ class ThingiverseApiClient(AbstractApiClient):
         PreferencesHelper.initSetting(Settings.THINGIVERSE_USER_NAME_PREFERENCES_KEY, "")
 
     @property
-    def available_views(self) -> List[str]:
-        return ["userLikes", "userCollections", "userThings", "userMakes", "popular", "featured", "newest"]
-
-    @property
     def user_id(self):
         return PreferencesHelper.getSettingValue(Settings.THINGIVERSE_USER_NAME_PREFERENCES_KEY)
 

--- a/ThingiBrowser/models/DriverOption.py
+++ b/ThingiBrowser/models/DriverOption.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Chris ter Beke.
+# Thingiverse plugin is released under the terms of the LGPLv3 or higher.
+from ..api.AbstractApiClient import AbstractApiClient
+
+
+class DriverOption:
+
+    def __init__(self, label: str, driver: AbstractApiClient) -> None:
+        self._label = label
+        self._driver = driver
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @property
+    def driver(self) -> AbstractApiClient:
+        return self._driver

--- a/ThingiBrowser/models/ViewOption.py
+++ b/ThingiBrowser/models/ViewOption.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Chris ter Beke.
+# Thingiverse plugin is released under the terms of the LGPLv3 or higher.
+from typing import Callable
+
+
+class ViewOption:
+
+    def __init__(self, label: str, query: Callable[[], None]) -> None:
+        self._label = label
+        self._query = query
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @property
+    def query(self) -> Callable[[], None]:
+        return self._query

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ testpaths = .
 python_files = Test*.py
 python_classes = Test
 python_functions = test
-addopts = --cov=ThingiBrowser --cov-fail-under=59
+addopts = --cov=ThingiBrowser --cov-fail-under=58

--- a/tests/TestPreferencesHelper.py
+++ b/tests/TestPreferencesHelper.py
@@ -33,5 +33,5 @@ class TestPreferencesHelper:
         preferences.setValue.assert_called_with("thingibrowser/test_setting_stored", "new_stored_value")
 
     def test_getAllSettings_returns_all_settings(self, preferences_helper):
-        all_settings = preferences_helper.getAllSettings()
-        assert len(all_settings) == 3
+        all_settings = preferences_helper.getAllSettings(drivers={}, views={})
+        assert len(all_settings) == 4

--- a/views/EnhancedComboBox.qml
+++ b/views/EnhancedComboBox.qml
@@ -6,23 +6,23 @@ ComboBox
 {
     id: comboBox
 
-    property string currentValue
-    property string valueRole: "value"
+    property string customCurrentValue
+    property string customValueRole: "value"
 
     function indexOfValue(value) {
-        if (model !== undefined) {
-            for(var idx in model) {
-                if (model[idx][valueRole] === value) {
-                    return idx
-                }
+        if (model == undefined) {
+            return -1
+        }
+        for (var idx in model) {
+            if (model[idx][customValueRole] === value) {
+                return idx
             }
         }
-        return -1
     }
 
     Binding {
         target: comboBox
-        property: "currentValue"
-        value: currentIndex < 0 ? "" : model[currentIndex][valueRole]
+        property: "customCurrentValue"
+        value: currentIndex < 0 ? "" : model[currentIndex][customValueRole]
     }
 }

--- a/views/ServiceSelector.qml
+++ b/views/ServiceSelector.qml
@@ -5,11 +5,11 @@ EnhancedComboBox
 {
     id: serviceSelector
     textRole: "label"
-    valueRole: "key"
+    customValueRole: "key"
     currentIndex: serviceSelector.indexOfValue(ThingiService.activeDriver)
     model: ThingiService.drivers
     onActivated: {
-        ThingiService.setActiveDriver(currentValue)
-        Analytics.trackEvent("driver_selected", "button_clicked")
+        ThingiService.setActiveDriver(customCurrentValue)
+        Analytics.trackEvent("driver_selected_" + customCurrentValue, "combobox_option_selected")
     }
 }

--- a/views/ThingFilesList.qml
+++ b/views/ThingFilesList.qml
@@ -8,6 +8,7 @@ ScrollView
 {
     property alias model: thingFilesList.model
     width: parent.width
+    contentWidth: width
     clip: true
 
     ListView

--- a/views/ThingiMain.qml
+++ b/views/ThingiMain.qml
@@ -24,7 +24,9 @@ ColumnLayout
         visible: !ThingiService.hasActiveThing
         Layout.fillHeight: true
         onVisibleChanged: {
-            Analytics.trackScreen("search")
+            if (visible) {
+                Analytics.trackScreen("search")
+            }
         }
     }
 
@@ -37,7 +39,9 @@ ColumnLayout
         visible: ThingiService.hasActiveThing && ThingiService.activeThing
         Layout.fillHeight: true
         onVisibleChanged: {
-            Analytics.trackScreen("details")
+            if (visible) {
+                Analytics.trackScreen("details")
+            }
         }
     }
 }

--- a/views/ThingiSettingsItem.qml
+++ b/views/ThingiSettingsItem.qml
@@ -41,11 +41,11 @@ RowLayout
         visible: thingiSettingsItem.type == "combobox"
         Layout.fillWidth: true
         textRole: "label"
-        valueRole: "key"
-        currentIndex: inputMenu.indexOfValue(thingiSettingsItem.value)
+        customValueRole: "key"
+        currentIndex: indexOfValue(thingiSettingsItem.value)
         model: thingiSettingsItem.options
         onActivated: {
-            ThingiService.saveSetting(thingiSettingsItem.key, currentValue)
+            ThingiService.saveSetting(thingiSettingsItem.key, customCurrentValue)
         }
     }
 
@@ -62,6 +62,6 @@ RowLayout
         target: thingiSettingsItem
         property: "value"
         when: thingiSettingsItem.type == "combobox"
-        value: inputMenu.currentIndex < 0 ? "" : inputMenu.model[inputMenu.currentIndex][inputMenu.valueRole]
+        value: inputMenu.currentIndex < 0 ? "" : inputMenu.model[inputMenu.currentIndex][inputMenu.customValueRole]
     }
 }

--- a/views/ViewSelector.qml
+++ b/views/ViewSelector.qml
@@ -1,70 +1,15 @@
 import QtQuick 2.2
 import QtQuick.Controls 2.3
 
-ComboBox
+EnhancedComboBox
 {
-    textRole: "text"
-    currentIndex: -1
-    model: ListModel {
-        id: viewsListModel
-        ListElement {
-            text: "My Likes"
-            value: "userLikes"
-        }
-        ListElement {
-            text: "My Collections"
-            value: "userCollections"
-        }
-        ListElement {
-            text: "My Things"
-            value: "userThings"
-        }
-        ListElement {
-            text: "My Makes"
-            value: "userMakes"
-        }
-        ListElement {
-            text: "Popular"
-            value: "popular"
-        }
-        ListElement {
-            text: "Featured"
-            value: "featured"
-        }
-        ListElement {
-            text: "Newest"
-            value: "newest"
-        }
-    }
+    id: viewSelector
+    textRole: "label"
+    customValueRole: "key"
+    currentIndex: viewSelector.indexOfValue(ThingiService.activeView)
+    model: ThingiService.views
     onActivated: {
-        switch(viewsListModel.get(currentIndex).value) {
-            case "userLikes":
-                ThingiService.getLiked()
-                Analytics.trackEvent("get_user_likes", "button_clicked")
-                break
-            case "userCollections":
-                ThingiService.getCollections()
-                Analytics.trackEvent("get_user_collections", "button_clicked")
-                break
-            case "userThings":
-                ThingiService.getMyThings()
-                Analytics.trackEvent("get_user_things", "button_clicked")
-                break
-            case "userMakes":
-                ThingiService.getMakes()
-                Analytics.trackEvent("get_user_makes", "button_clicked")
-                break
-            case "popular":
-                ThingiService.getPopular()
-                Analytics.trackEvent("get_popular", "button_clicked")
-                break
-            case "featured":
-                ThingiService.getFeatured()
-                Analytics.trackEvent("get_featured", "button_clicked")
-                break
-            case "newest":
-                ThingiService.getNewest()
-                Analytics.trackEvent("get_newest", "button_clicked")
-        }
+        ThingiService.setActiveView(customCurrentValue)
+        Analytics.trackEvent("view_selected_" + customCurrentValue, "combobox_option_selected")
     }
 }


### PR DESCRIPTION
* Refactor view selector to Python defined list.
* Add user setting for default view (defaults to 'popular').
* Make `EnhancedComboBox` work on Qt 5.14+ by not overriding a FINAL property (fixes #37).
* Remove QML warning about binding loop for `contentWidth` property of `ThingFilesList`.
* Fix tracking page views in Analytics twice.