### PR TITLE
Refactor to support parallel login flows

### DIFF
--- a/ThingiBrowser/api/ImplicitAuthRequestHandler.py
+++ b/ThingiBrowser/api/ImplicitAuthRequestHandler.py
@@ -36,12 +36,16 @@ class ImplicitAuthRequestHandler(BaseHTTPRequestHandler):
             # This is a security feature of OAuth2 which prevents following an implicit flow from a server application.
             self._htmlResponse("AuthenticationRedirect")
             return
+        state = self._getParam(query, "state")
+        if not state:
+            self._exceptionResponse("State could not be found in query")
+            return
         access_token = self._getParam(query, "access_token")
         if not access_token:
             self._exceptionResponse("Access token could not be found in query")
             return
         self._htmlResponse("AuthenticationReceived")
-        self.onTokenReceived.emit(access_token)
+        self.onTokenReceived.emit(state, access_token)
 
     def _htmlResponse(self, page_name: str) -> None:
         self.send_response(200)

--- a/ThingiBrowser/api/LocalAuthService.py
+++ b/ThingiBrowser/api/LocalAuthService.py
@@ -2,7 +2,6 @@
 # ThingiBrowser plugin is released under the terms of the LGPLv3 or higher.
 import threading
 from http.server import HTTPServer
-from typing import Optional
 
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
@@ -12,34 +11,28 @@ from UM.Signal import Signal  # type: ignore
 from ..api.ImplicitAuthRequestHandler import ImplicitAuthRequestHandler
 
 
+# We have a 'global' server and thread that we can re-use.
+_server = HTTPServer(("0.0.0.0", 55444), ImplicitAuthRequestHandler)
+_thread = threading.Thread(name="LocalAuthService", target=_server.serve_forever, daemon=True)
+
+
 class LocalAuthService:
     """
-    Service that organizes authentication flows with web services.
+    Service that organizes multiple parallel authentication flows with web services.
     """
 
     # Signal emitted with as first argument the received token.
     # We use a signal instead of a callback function in order to pass the token back to the Qt thread safely.
     onTokenReceived = Signal()
 
-    _server = HTTPServer(("0.0.0.0", 55444), ImplicitAuthRequestHandler)
-    _thread = threading.Thread(name="LocalAuthService", target=_server.serve_forever, daemon=True)
-
-    def start(self, url: str) -> None:
+    @staticmethod
+    def start(url: str) -> None:
         """
         Start the server in a separate thread and open the authentication page.
         """
-        if not self._thread.isAlive():
-            # Only start the thread once. From the first use onward we keep it running.
-            self._thread.start()
-        ImplicitAuthRequestHandler.onTokenReceived.connect(self._onTokenReceived)
+        if not _thread.is_alive():
+            _thread.start()
         QDesktopServices.openUrl(QUrl(url))
 
-    def _onTokenReceived(self, token: Optional[str] = None) -> None:
-        """
-        Handler for when an implicit auth token was received.
-        Closes the server so the port can be re-used.
-        :param token: The received auth token.
-        """
-        ImplicitAuthRequestHandler.onTokenReceived.disconnect(self._onTokenReceived)
-        self.onTokenReceived.emit(token)
-        # FIXME: Figure out how to stop the server and join the thread without blocking Cura for a while
+
+ImplicitAuthRequestHandler.onTokenReceived.connect(LocalAuthService.onTokenReceived)

--- a/ThingiBrowser/api/LocalAuthService.py
+++ b/ThingiBrowser/api/LocalAuthService.py
@@ -2,18 +2,12 @@
 # ThingiBrowser plugin is released under the terms of the LGPLv3 or higher.
 import threading
 from http.server import HTTPServer
+from typing import Optional
 
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 
 from UM.Signal import Signal  # type: ignore
-
-from ..api.ImplicitAuthRequestHandler import ImplicitAuthRequestHandler
-
-
-# We have a 'global' server and thread that we can re-use.
-_server = HTTPServer(("0.0.0.0", 55444), ImplicitAuthRequestHandler)
-_thread = threading.Thread(name="LocalAuthService", target=_server.serve_forever, daemon=True)
 
 
 class LocalAuthService:
@@ -21,18 +15,25 @@ class LocalAuthService:
     Service that organizes multiple parallel authentication flows with web services.
     """
 
+    _server = None  # type: Optional[HTTPServer]
+    _thread = None  # type: Optional[threading.Thread]
+
     # Signal emitted with as first argument the received token.
     # We use a signal instead of a callback function in order to pass the token back to the Qt thread safely.
     onTokenReceived = Signal()
 
-    @staticmethod
-    def start(url: str) -> None:
+    @classmethod
+    def start(cls, url: str) -> None:
         """
         Start the server in a separate thread and open the authentication page.
         """
-        if not _thread.is_alive():
-            _thread.start()
+        if not cls._server:
+            # FIXME: when importing globally this causes issues with UM.Signal.Signal in PyTest
+            from ..api.ImplicitAuthRequestHandler import ImplicitAuthRequestHandler
+            ImplicitAuthRequestHandler.onTokenReceived.connect(cls.onTokenReceived)
+            cls._server = HTTPServer(("0.0.0.0", 55444), ImplicitAuthRequestHandler)
+        if not cls._thread:
+            cls._thread = threading.Thread(name="LocalAuthService", target=cls._server.serve_forever, daemon=True)
+        if not cls._thread.is_alive():
+            cls._thread.start()
         QDesktopServices.openUrl(QUrl(url))
-
-
-ImplicitAuthRequestHandler.onTokenReceived.connect(LocalAuthService.onTokenReceived)

--- a/ThingiBrowser/drivers/myminifactory/MyMiniFactoryApiClient.py
+++ b/ThingiBrowser/drivers/myminifactory/MyMiniFactoryApiClient.py
@@ -21,8 +21,6 @@ class MyMiniFactoryApiClient(AbstractApiClient):
     def __init__(self) -> None:
         self._username = None  # type: Optional[str]
         self._auth_state = None  # type: Optional[str]
-        self._auth_service = LocalAuthService()
-        self._auth_service.onTokenReceived.connect(self._onTokenReceived)
         access_token = PreferencesHelper.initSetting(Settings.MYMINIFACTORY_API_TOKEN_KEY)
         if access_token and access_token != "":
             # Get the username if we already have a token stored.
@@ -37,7 +35,8 @@ class MyMiniFactoryApiClient(AbstractApiClient):
             "response_type": "token",
             "state": self._auth_state
         }))
-        self._auth_service.start(url)
+        LocalAuthService.onTokenReceived.connect(self._onTokenReceived)
+        LocalAuthService.start(url)
 
     def clearAuthentication(self) -> None:
         PreferencesHelper.setSetting(Settings.MYMINIFACTORY_API_TOKEN_KEY, "")
@@ -45,6 +44,7 @@ class MyMiniFactoryApiClient(AbstractApiClient):
     def _onTokenReceived(self, state: str, token: Optional[str] = None) -> None:
         if state != self._auth_state:
             return
+        LocalAuthService.onTokenReceived.disconnect(self._onTokenReceived)
         if not token:
             return
         PreferencesHelper.setSetting(Settings.MYMINIFACTORY_API_TOKEN_KEY, token)

--- a/ThingiBrowser/drivers/thingiverse/ThingiverseApiClient.py
+++ b/ThingiBrowser/drivers/thingiverse/ThingiverseApiClient.py
@@ -19,8 +19,6 @@ class ThingiverseApiClient(AbstractApiClient):
 
     def __init__(self) -> None:
         self._auth_state = None  # type: Optional[str]
-        self._auth_service = LocalAuthService()
-        self._auth_service.onTokenReceived.connect(self._onTokenReceived)
         PreferencesHelper.initSetting(Settings.THINGIVERSE_API_TOKEN_KEY)
         super().__init__()
 
@@ -31,7 +29,8 @@ class ThingiverseApiClient(AbstractApiClient):
             "response_type": "token",
             "state": self._auth_state
         }))
-        self._auth_service.start(url)
+        LocalAuthService.onTokenReceived.connect(self._onTokenReceived)
+        LocalAuthService.start(url)
 
     def clearAuthentication(self) -> None:
         PreferencesHelper.setSetting(Settings.THINGIVERSE_API_TOKEN_KEY, "")
@@ -39,6 +38,7 @@ class ThingiverseApiClient(AbstractApiClient):
     def _onTokenReceived(self, state: str, token: Optional[str] = None) -> None:
         if state != self._auth_state:
             return
+        LocalAuthService.onTokenReceived.disconnect(self._onTokenReceived)
         if not token:
             return
         PreferencesHelper.setSetting(Settings.THINGIVERSE_API_TOKEN_KEY, token)

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ testpaths = .
 python_files = Test*.py
 python_classes = Test
 python_functions = test
-addopts = --cov=ThingiBrowser --cov-fail-under=57
+addopts = --cov=ThingiBrowser --cov-fail-under=60

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,7 @@ eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 export PYENV_VIRTUALENV_DISABLE_PROMPT=1
 pyenv activate cura
+pip3 install -r requirements-testing.txt
 pytest
 mypy ThingiBrowser
 pyenv deactivate

--- a/tests/api/TestLocalAuthService.py
+++ b/tests/api/TestLocalAuthService.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2020.
+# ThingiBrowser plugin is released under the terms of the LGPLv3 or higher.
+from unittest.mock import MagicMock, patch, DEFAULT
+
+import pytest
+import requests
+from surrogate import surrogate
+from typing import Callable
+
+
+class SignalMock(MagicMock):
+
+    def connect(self, callback: Callable) -> None:
+        pass
+
+    def emit(self, *args, **kwargs) -> None:
+        pass
+
+
+class TestLocalAuthService:
+
+    @pytest.fixture(scope="session")
+    @surrogate("UM.Signal.Signal")
+    def auth_service(self):
+        with patch("UM.Signal.Signal", SignalMock):
+            from ...ThingiBrowser.api.LocalAuthService import LocalAuthService
+            auth_service = LocalAuthService()
+            auth_service.start("https://ultimaker.com")
+            return auth_service
+
+    def test_server_callback_url(self, auth_service):
+        response = requests.get("http://localhost:55444/callback#access_token=derp&state=hi")
+        assert response.status_code == 200
+
+    def test_server_redirected_callback_url(self, auth_service):
+        with patch.multiple(SignalMock, connect=DEFAULT, emit=DEFAULT) as mocked_signal:
+            response = requests.get("http://localhost:55444/callback?access_token=derp&state=hi")
+            assert response.status_code == 200
+            mocked_signal["emit"].assert_called_with("hi", "derp")
+
+    def test_server_invalid_url(self, auth_service):
+        response = requests.get("http://localhost:55444/derp")
+        assert response.status_code == 404

--- a/tests/drivers/myminifactory/TestMyMiniFactoryApiClient.py
+++ b/tests/drivers/myminifactory/TestMyMiniFactoryApiClient.py
@@ -14,6 +14,7 @@ class TestMyMiniFactoryApiClient:
 
     @pytest.fixture
     @surrogate("cura.CuraApplication.CuraApplication")
+    @surrogate("UM.Signal.Signal")
     def api_client(self, application):
         with patch("cura.CuraApplication.CuraApplication", application):
             from ....ThingiBrowser.drivers.myminifactory.MyMiniFactoryApiClient import MyMiniFactoryApiClient

--- a/tests/drivers/thingiverse/TestThingiverseApiClient.py
+++ b/tests/drivers/thingiverse/TestThingiverseApiClient.py
@@ -13,6 +13,7 @@ class TestThingiverseApiClient:
 
     @pytest.fixture
     @surrogate("cura.CuraApplication.CuraApplication")
+    @surrogate("UM.Signal.Signal")
     def api_client(self, application):
         with patch("cura.CuraApplication.CuraApplication", application):
             from ....ThingiBrowser.drivers.thingiverse.ThingiverseApiClient import ThingiverseApiClient


### PR DESCRIPTION
This change allows users to click on the sign in buttons for Thingiverse and MyMiniFactory in parallel. We use the `state` parameter of OAuth2 to distinguish between the multiple login flows going on. I've also added some tests for the new authorization flows.