### PR TITLE
Remove auth data on failed request

### DIFF
--- a/ThingiBrowser/ThingiBrowserService.py
+++ b/ThingiBrowser/ThingiBrowserService.py
@@ -551,6 +551,8 @@ class ThingiBrowserService(QObject):
         mb.setText("{0} indicated that you need to sign in. Please sign into your {0} account and try again.".format(
             self._drivers[self.activeDriver].label))
         mb.exec()
+        # Remove any existing authentication data as it's clearly incorrect.
+        self.clearAuthenticationForDriver(self.activeDriver)
 
     @staticmethod
     def _showApiResponseError(error: Optional[ApiError] = None) -> None:


### PR DESCRIPTION
When a request failed because of incorrect authentication we now automatically remove authentication data for the active driver (that did the request) so the user knows they need to sign in again. This happens when the authentication tokens have expired. Before you could already sign out manually and then sign in again, but it wasn't as obvious.