### PR TITLE
Remove the new login flow for Thingiverse

### DIFF
--- a/ThingiBrowser/PreferencesHelper.py
+++ b/ThingiBrowser/PreferencesHelper.py
@@ -34,33 +34,46 @@ class PreferencesHelper:
         :return: The settings dict.
         """
         return [
-            {
-                "type": "cta_button",
-                "key": Settings.THINGIVERSE_API_TOKEN_KEY,
-                "value": cls.getSettingValue(Settings.THINGIVERSE_API_TOKEN_KEY),
-                "label": "Thingiverse Account",
-                "driver": "thingiverse"
-            },
+            # FIXME: Waiting for Thingiverse app approval
+            # {
+            #     "type": "cta_button",
+            #     "key": Settings.THINGIVERSE_API_TOKEN_KEY,
+            #     "value": cls.getSettingValue(Settings.THINGIVERSE_API_TOKEN_KEY),
+            #     "label": "Thingiverse Account",
+            #     "driver": "thingiverse"
+            # },
             {
                 "type": "cta_button",
                 "key": Settings.MYMINIFACTORY_API_TOKEN_KEY,
                 "value": cls.getSettingValue(Settings.MYMINIFACTORY_API_TOKEN_KEY),
                 "label": "MyMiniFactory Account",
-                "driver": "myminifactory"
+                "driver": "myminifactory",
+                "description": "Sign in with your MyMiniFactory account to see your own likes and makes in the plugin."
+            },
+            {
+                "type": "text",
+                "key": Settings.THINGIVERSE_USER_NAME_PREFERENCES_KEY,
+                "value": cls.getSettingValue(Settings.THINGIVERSE_USER_NAME_PREFERENCES_KEY),
+                "label": "Thingiverse username",
+                "description": "The username of the Thingiverse account to show likes and makes for. "
+                               "Thingiverse is no longer actively maintained so the improved sign in flow as used for "
+                               "MyMiniFactory cannot be implemented for Thingiverse."
             },
             {
                 "type": "combobox",
                 "key": Settings.DEFAULT_API_CLIENT_PREFERENCES_KEY,
                 "value": cls.getSettingValue(Settings.DEFAULT_API_CLIENT_PREFERENCES_KEY),
                 "label": "Default repository service",
-                "options": drivers
+                "options": drivers,
+                "description": "Which 3D file repository to use when the plugin starts."
             },
             {
                 "type": "combobox",
                 "key": Settings.DEFAULT_VIEW_PREFERENCES_KEY,
                 "value": cls.getSettingValue(Settings.DEFAULT_VIEW_PREFERENCES_KEY),
                 "label": "Default view",
-                "options": views
+                "options": views,
+                "description": "Which view to use when the plugin starts."
             }
         ]
 

--- a/ThingiBrowser/Settings.py
+++ b/ThingiBrowser/Settings.py
@@ -20,7 +20,9 @@ class Settings:
     PER_PAGE = 20
 
     # Thingiverse API options
-    THINGIVERSE_CLIENT_ID = "bf4d7b7ee5228a368491"
+    THINGIVERSE_USER_NAME_PREFERENCES_KEY = "user_name"
+    # FIXME: Waiting for Thingiverse app approval
+    THINGIVERSE_CLIENT_ID = ""
     THINGIVERSE_API_TOKEN = "96f45d208a4b1d99bff728038162b354"  # for public endpoints
 
     # MyMiniFactory API options

--- a/tests/drivers/thingiverse/TestThingiverseApiClient.py
+++ b/tests/drivers/thingiverse/TestThingiverseApiClient.py
@@ -29,15 +29,15 @@ class TestThingiverseApiClient:
 
     def test_getThingsLikedByUserQuery(self, api_client):
         query = api_client.getThingsLikedByUserQuery()
-        assert query == "users/me/likes"
+        assert query == "users/404_this_user_does_not_exist/likes"
 
     def test_getThingsByUserQuery(self, api_client):
         query = api_client.getThingsByUserQuery()
-        assert query == "users/me/things"
+        assert query == "users/404_this_user_does_not_exist/things"
 
     def test_getThingsMadeByUserQuery(self, api_client):
         query = api_client.getThingsMadeByUserQuery()
-        assert query == "users/me/copies"
+        assert query == "users/404_this_user_does_not_exist/copies"
 
     def test_getPopularThingsQuery(self, api_client):
         query = api_client.getPopularThingsQuery()

--- a/views/ThingiSettings.qml
+++ b/views/ThingiSettings.qml
@@ -44,6 +44,7 @@ Window
                 key: modelData.key
                 label: modelData.label
                 value: modelData.value
+                description: modelData.description
                 options: modelData.options
                 driver: modelData.driver
             }

--- a/views/ThingiSettingsItem.qml
+++ b/views/ThingiSettingsItem.qml
@@ -16,14 +16,33 @@ RowLayout
     property var value: ""
     property var options: []
     property var driver: ""
+    property var description: ""
 
     Label
     {
+        id: label
         text: thingiSettingsItem.label
         font: UM.Theme.getFont("default")
         color: UM.Theme.getColor("text")
         renderType: Text.NativeRendering
         Layout.preferredWidth: parent.width / 2 // causes both the label and input to be the same width
+
+        ToolTip {
+            id: labelToolTip
+            visible: labelHoverArea.containsMouse
+            width: thingiSettingsItem.width * 0.75
+            delay: 500
+            contentItem: Text {
+                text: thingiSettingsItem.description
+                wrapMode: Text.WordWrap
+            }
+        }
+
+        MouseArea {
+            id: labelHoverArea
+            anchors.fill: parent
+            hoverEnabled: true
+        }
     }
 
     TextField


### PR DESCRIPTION
After holding an ["official poll" on Reddit](https://www.reddit.com/r/thingiverse/comments/hwhfvb/is_thingiverse_dead/), many people seem to believe that Thingiverse is no longer actively maintained. To that extend, I've removed the new sign-in flow for Thingiverse (and brought back the old username-based flow) as it's very unlikely that Thingiverse will ever respond to our new app approval request. The new flow still works for MyMiniFactory.

I also added more descriptive labels for all the settings that appear as a tooltip when hovering over the setting label.