### PR TITLE
Fixed for QT 5.15, renamed implicitIndicatorWidth

### DIFF
--- a/views/EnhancedComboBox.qml
+++ b/views/EnhancedComboBox.qml
@@ -8,7 +8,7 @@ ComboBox
 
     property string customCurrentValue
     property string customValueRole: "value"
-    property int implicitIndicatorWidth: 20
+    property int customImplicitIndicatorWidth: 20
     property bool sizeToContents: false
     property int modelWidth
 
@@ -36,7 +36,7 @@ ComboBox
             textMetrics.text = model[idx][textRole]
             maxWidth = Math.max(textMetrics.width, maxWidth)
         }
-        modelWidth = maxWidth + (implicitIndicatorWidth * 2) + leftPadding + rightPadding + contentItem.leftPadding + contentItem.rightPadding
+        modelWidth = maxWidth + (customImplicitIndicatorWidth * 2) + leftPadding + rightPadding + contentItem.leftPadding + contentItem.rightPadding
     }
 
     Binding {


### PR DESCRIPTION
Trying this against Qt 5.15 highlighted another issue related to #37 this time with implicitIndicatorWidth.

https://doc.qt.io/Qt-5/qml-qtquick-controls2-combobox.html#implicitIndicatorWidth-prop